### PR TITLE
fix(auth): polir fluxo de recuperação de senha (UX link expirado + ordem de scripts)

### DIFF
--- a/auth/index.html
+++ b/auth/index.html
@@ -48,21 +48,19 @@
         <button id="btnSendLink" class="btn" style="margin-top: 8px">
           Enviar link
         </button>
-        <p class="muted" style="margin-top: 8px">
-          O link abrirá esta página (<code>/auth/index.html</code>).
-        </p>
-      </div>
+       </div>
 
       <p id="authMsg" class="muted" style="margin-top: 12px"></p>
       <p class="muted" style="margin-top: 8px">
-        <a href="../index.html">Voltar ao login</a>
+        <!-- no bloco "Definir nova senha" -->
+      <a href="../index.html" data-back-login style="display:none">Voltar ao login</a>
       </p>
     </div>
 
     <!-- libs e client (ordem importa) -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.46.1/dist/umd/supabase.js"></script>
     <script src="../assets/js/supa.js?v=fix1"></script>
-
+    <script src="../assets/js/auth.reset.js" defer></script>
     <script>
       const $ = (id) => document.getElementById(id);
       const setMsg = (type, text) => {


### PR DESCRIPTION
### O que foi feito
- Remove a frase “O link abrirá esta página (/auth/index.html)” na tela de reset.
- Mantém “Voltar ao login” somente quando o link estiver inválido/expirado.
- Link válido: redefine a senha, faz signOut e redireciona para '/' (sem sessão).
- Garante ordem dos scripts: `supa.js?v=fix1` → `auth.reset.js`.

### Arquivos alterados
- auth/index.html
- assets/js/auth.reset.js

### Checklist
- [ ] Link válido redefine a senha e retorna à home **deslogado**.
- [ ] Link expirado mostra mensagem + **“Voltar ao login”**.
- [ ] A frase removida **não aparece** em nenhum cenário.
- [ ] Testado localmente em janela normal/privada.
