### PR TITLE
feat(terms): aceite versãoado + impressão PDF (com e-mail)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
+  
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -7,111 +8,13 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/assets/css/base.css" />
     <link rel="stylesheet" href="/assets/css/app.css" />
-    <link rel="stylesheet" href="/assets/css/activation.css?v=1">
+    <link rel="stylesheet" href="/assets/css/activation.css?v=1" />
     <style>
-
-
-      /* fallback para debug: garantir que .hide exista */
       .hide { display: none !important; }
-
-      /* ===== Modal: escolher papel ===== */
-      .modal {
-        position: fixed; inset: 0; display: none;
-        align-items: center; justify-content: center;
-        background: rgba(7,12,22,.6);
-        z-index: 40; padding: 24px;
-      }
-      .modal.is-open { display: flex; }
-      .modal__box {
-        background:#0e1421; color:#e8eefb;
-        border:1px solid rgba(255,255,255,.06);
-        border-radius:16px; box-shadow: 0 10px 40px rgba(0,0,0,.5);
-        padding: 24px; max-width:520px; width:100%;
-      }
-      .modal__actions { display:flex; gap:12px; margin-top:12px; }
-      .modal__actions .btn { flex:1; }
-      body.modal-open { overflow: hidden; }
-
-      /* ===== Checklist de ativação (UI leve, não impacta tema) ===== */
-      .activation-card { max-width:980px; margin:24px auto; }
-      .activation-card .head {
-        display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:10px;
-      }
-      .activation-title { font:800 18px/1.3 Inter,system-ui,sans-serif; color:#e8eefb; }
-      .activation-progress { color:#cfe3ff; font-size:14px; }
-      .activation-list { list-style:none; display:grid; gap:10px; margin-top:8px; }
-      .activation-item {
-        display:flex; align-items:center; gap:12px; padding:10px 12px;
-        border:1px solid rgba(255,255,255,.08); border-radius:12px;
-        background: rgba(255,255,255,.03);
-      }
-      .activation-item .badge {
-        min-width:24px; height:24px; border-radius:999px; display:flex; align-items:center; justify-content:center;
-        font-weight:800; background:rgba(56,189,248,.12); color:#86d5ff; font-size:13px;
-      }
-      .activation-item .info { flex:1; }
-      .activation-item .title { font-weight:700; color:#e8eefb; }
-      .activation-item .desc { color:#cfe3ff; font-size:13px; }
-      .activation-item .status {
-        font-size:12px; font-weight:700; padding:4px 8px; border-radius:999px; border:1px solid rgba(255,255,255,.12);
-      }
-      .st-ok { color:#bff5df; border-color:#2dd4bf; }
-      .st-pending { color:#ffe9b6; border-color:#fbbf24; }
-      .st-missing { color:#ffd1d1; border-color:#f87171; }
-      .btn.sm { height:34px; padding:0 12px; font-size:14px; }
-      @media (max-width:640px){ .activation-card .head{ flex-direction:column; align-items:flex-start; } }
     </style>
-
-
-<style>
-  /* === Legibilidade melhorada: ativação (tipografia + espaçamentos) === */
-  .activation-card { max-width: 980px; margin: 28px auto; }
-  .activation-card .head { gap: 14px; margin-bottom: 12px; }
-  .activation-title { font-weight: 800; font-size: 20px; line-height: 1.35; }
-  .activation-progress { font-size: 15px; }
-
-  .activation-list { gap: 12px; }
-
-  .activation-item {
-    padding: 14px 16px; border-radius: 14px;
-  }
-  .activation-item .badge {
-    min-width: 28px; height: 28px; font-size: 14px;
-  }
-  .activation-item .title {
-    font-size: 19.5px; line-height: 1.35;
-  }
-  .activation-item .desc {
-    font-size: 18.5px; line-height: 1.5; color: #d7e9ff;
-  }
-  .activation-item .status {
-    font-size: 16.5px; padding: 6px 10px; border-radius: 999px;
-  }
-
-  /* Botão compacto mais confortável (min 40px) */
-  .btn.sm { height: 40px; padding: 0 14px; font-size: 15px; }
-
-  /* Hover/focus discretos (acessibilidade) */
-  .btn.sm:focus-visible { outline: 2px solid #89c6ff; outline-offset: 2px; }
-  .activation-item .status:focus-visible { outline: 2px solid #89c6ff; outline-offset: 2px; }
-
-  /* Mobile: dá mais um passo no tamanho e nos alvos de toque */
-  @media (max-width: 640px) {
-    .activation-title { font-size: 21px; }
-    .activation-item { padding: 16px; }
-    .activation-item .title { font-size: 17px; }
-    .activation-item .desc { font-size: 15px; }
-    .activation-item .badge { min-width: 30px; height: 30px; font-size: 15px; }
-    .btn.sm { height: 44px; padding: 0 16px; font-size: 16px; }
-  }
-</style>
-
-
-
   </head>
-
   <body class="wrap has-topbar">
-    <!-- ====================== TOPBAR (mostra apenas estado logado) ====================== -->
+    <!-- ====================== TOPBAR ====================== -->
     <header class="topbar">
       <div class="container">
         <a class="brand" href="/index.html" aria-label="Bidly">
@@ -126,7 +29,6 @@
         </nav>
 
         <div class="actions">
-          <!-- Aparece só quando logado -->
           <span class="muted" data-auth>
             Logado como: <b id="userEmail">—</b>
             <span id="userRoleText"> • Perfil: —</span>
@@ -134,7 +36,6 @@
 
           <button id="btnOutTop" class="btn hide" data-auth>Sair</button>
 
-          <!-- Hamburger (menu móvel) -->
           <button class="menu-toggle" aria-expanded="false" aria-label="Abrir menu">
             <span></span><span></span><span></span>
           </button>
@@ -148,8 +49,6 @@
           <a href="/index.html#como-funciona" class="mm-link">Como funciona</a>
           <a href="/index.html#precos" class="mm-link">Preços</a>
           <a href="/index.html#faq" class="mm-link">FAQ</a>
-
-          <!-- Ações de autenticado (aparecem após applyAuthUI/requireAuth) -->
           <div class="mm-actions hide" data-auth>
             <button id="btnOutMobile" class="btn ghost mm-btn">Sair</button>
           </div>
@@ -158,7 +57,7 @@
     </header>
     <!-- ==================== /TOPBAR ==================== -->
 
-    <!-- Conteúdo da aplicação -->
+    <!-- ==================== CONTEÚDO ==================== -->
     <section class="card card-pad activation-card" id="activationCard">
       <div class="head">
         <div class="activation-title">Ativação da conta</div>
@@ -166,7 +65,7 @@
       </div>
 
       <ul class="activation-list">
-        <!-- Dados -->
+        <!-- 1) Dados -->
         <li class="activation-item" id="row-dados">
           <div class="badge">1</div>
           <div class="info">
@@ -177,7 +76,7 @@
           <button class="btn outline sm" id="btn-dados">Preencher</button>
         </li>
 
-        <!-- Termos -->
+        <!-- 2) Termos -->
         <li class="activation-item" id="row-termos">
           <div class="badge">2</div>
           <div class="info">
@@ -188,7 +87,7 @@
           <button class="btn outline sm" id="btn-termos">Ler & aceitar</button>
         </li>
 
-        <!-- Financeiro -->
+        <!-- 3) Financeiro -->
         <li class="activation-item" id="row-fin">
           <div class="badge">3</div>
           <div class="info">
@@ -199,7 +98,7 @@
           <button class="btn outline sm" id="btn-fin">Configurar</button>
         </li>
 
-        <!-- Documentos (KYC/KYB) -->
+        <!-- 4) Documentos -->
         <li class="activation-item" id="row-docs">
           <div class="badge">4</div>
           <div class="info">
@@ -212,254 +111,86 @@
       </ul>
     </section>
 
-    <!-- (Opcional) área para exibir erro de boot caso algo dê errado -->
-    <section id="bootError" class="card card-pad hide" style="max-width: 980px; margin: 16px auto"></section>
+    <!-- Erro de boot -->
+    <section id="bootError" class="card card-pad hide" style="max-width:980px; margin:16px auto"></section>
 
-    <!-- ===== Modal: escolher papel (aparece só se faltar role) ===== -->
+    <!-- Modal: escolher papel (se não houver role) -->
     <div id="modalRole" class="modal" role="dialog" aria-modal="true" aria-labelledby="modalRoleTitle">
       <div class="modal__box">
         <h3 id="modalRoleTitle" style="margin:0 0 8px">Como você quer usar a Bidly?</h3>
-        <p class="muted" style="margin:0 0 16px">
-          Escolha para continuar. (Você pode solicitar mudança depois com nosso suporte.)
-        </p>
+        <p class="muted" style="margin:0 0 16px">Escolha para continuar. (Você pode solicitar mudança depois com nosso suporte.)</p>
         <div class="modal__actions">
           <button id="btnRoleCompany" class="btn">Sou Empresa</button>
-          <button id="btnRoleVendor"  class="btn outline">Sou Fornecedor</button>
+          <button id="btnRoleVendor" class="btn outline">Sou Fornecedor</button>
         </div>
       </div>
     </div>
 
-    <!-- ============================ SCRIPTS (ORDEM IMPORTA) ============================ -->
-    <!-- 1) UMD do Supabase -->
+
+    
+                <!-- ===== Modal: Termos de uso ===== -->
+      <div id="termsModal" class="modal hide" aria-hidden="true" role="dialog" aria-modal="true">
+        <div class="modal-dialog" role="document" aria-labelledby="termsTitle">
+          <div class="modal-header">
+            <h3 id="termsTitle">Termos de uso</h3>
+            <button class="icon" data-close="1" aria-label="Fechar" title="Fechar">×</button>
+          </div>
+
+          <div class="terms-card">
+            <div class="terms-box" id="termsBox">
+              <!-- o HTML dos termos é carregado aqui via JS -->
+            </div>
+
+            <label class="agree" for="chkAgree">
+              <input type="checkbox" id="chkAgree" />
+              <span>Li e concordo com os termos de uso.</span>
+            </label>
+
+            <small id="scrollHint" class="muted">Role até o fim do documento para habilitar “Aceitar”.</small>
+          </div>
+
+          <div class="modal-actions">
+            <span id="termsMeta" class="meta"></span>
+            <button id="btnPrintTerms" type="button" class="btn link">Salvar PDF</button>
+            <div class="spacer"></div>
+            <button type="button" class="btn ghost btn-cancel" data-close="1">Cancelar</button>
+            <button id="btnAcceptTerms" type="button" class="btn primary" disabled>Aceitar</button>
+          </div>
+        </div>
+      </div>
+      <!-- ===== /Modal ===== -->
+
+
+
+    <!-- ============================ SCRIPTS ============================ -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.46.1/dist/umd/supabase.js"></script>
-
-    <!-- 2) Núcleo unificado (connectSupabase/requireAuth/applyAuthUI/logoutLocal) -->
     <script src="/assets/js/supa.js?v=1"></script>
-
-    <!-- 3) Lógica base (já existente no projeto) -->
     <script src="/assets/js/app.js?v=ROLE3"></script>
+    <script src="/assets/js/activation.js?v=1"></script>
 
-    <!-- 4) Helpers (role/modal + checklist) -->
-    <script>
-      /* ====== Role: rótulo no topo ====== */
-      function setRoleText(role) {
-        const out = document.getElementById("userRoleText");
-        const label = role === "company" ? "Empresa" :
-          (role === "vendor" || role === "supplier") ? "Fornecedor" : "—";
-        if (out) out.textContent = " • Perfil: " + label;
-      }
-      function openRoleModal() {
-        document.getElementById("modalRole")?.classList.add("is-open");
-        document.body.classList.add("modal-open");
-      }
-      function closeRoleModal() {
-        document.getElementById("modalRole")?.classList.remove("is-open");
-        document.body.classList.remove("modal-open");
-      }
-      async function ensureRole() {
-        const { data: s } = await sb.auth.getSession();
-        const session = s?.session; if (!session) return;
-        const uid = session.user.id;
-        let { data, error } = await sb.from("profiles").select("id, role").eq("id", uid).maybeSingle();
-        if (error) console.warn("[role] select error:", error);
-        if (data?.role) { setRoleText(data.role); return; }
-        openRoleModal();
-        const btnCompany = document.getElementById("btnRoleCompany");
-        const btnVendor  = document.getElementById("btnRoleVendor");
-        async function choose(role) {
-          btnCompany.disabled = btnVendor.disabled = true;
-          try {
-            const payload = { role, accept_terms_at: new Date().toISOString() };
-            if (!data) {
-              const ins = await sb.from("profiles").insert({ id: uid, ...payload }).select().maybeSingle();
-              if (ins.error) throw ins.error;
-            } else {
-              const upd = await sb.from("profiles").update(payload).eq("id", uid);
-              if (upd.error) throw upd.error;
-            }
-            setRoleText(role); closeRoleModal();
-            // Após escolher papel, recarrega checklist
-            await renderActivationChecklist();
-          } catch (e) {
-            console.error("[role] save error:", e);
-            alert("Não foi possível salvar sua escolha agora. Tente novamente.");
-          } finally {
-            btnCompany.disabled = btnVendor.disabled = false;
-          }
-        }
-        btnCompany.onclick = () => choose("company");
-        btnVendor.onclick  = () => choose("vendor");
-      }
-
-      /* ====== Checklist de ativação (somente leitura/MVP) ====== */
-      function setStatus(elId, state) {
-        const el = document.getElementById(elId);
-        if (!el) return;
-        el.classList.remove("st-ok","st-pending","st-missing");
-        if (state === "ok") el.classList.add("st-ok"), el.textContent = "Concluído";
-        else if (state === "pending") el.classList.add("st-pending"), el.textContent = "Pendente";
-        else el.classList.add("st-missing"), el.textContent = "Faltando";
-      }
-
-      async function renderActivationChecklist() {
-        const { data: s } = await sb.auth.getSession();
-        const session = s?.session; if (!session) return;
-        const uid = session.user.id;
-
-        // Busca dados essenciais do perfil (sem uploads nesta fase)
-        const { data, error } = await sb
-          .from("profiles")
-          .select("role, company_name, document, pix_key, accept_terms_at, terms_version, display_name, linkedin_url")
-          .eq("id", uid)
-          .maybeSingle();
-
-        if (error) { console.warn("[activation] select error:", error); return; }
-
-        const role = data?.role || null;
-        const isCompany = role === "company";
-        const isVendor  = role === "vendor" || role === "supplier";
-
-        // Regras de status — MVP
-        const dadosOK = isCompany
-          ? !!(data?.company_name && data?.document)
-          : !!(data?.document || (data?.display_name && data?.linkedin_url));
-
-        const termosOK = !!data?.accept_terms_at;
-
-        const finOK = isCompany
-          ? false // empresa: pendente até definirmos campos de cobrança (próximo batch)
-          : !!data?.pix_key; // fornecedor: pix_key preenchido já conta
-
-        const docsOK = false; // Upload/aprovação ainda não implementados
-
-        setStatus("st-dados",   dadosOK  ? "ok" : "pending");
-        setStatus("st-termos",  termosOK ? "ok" : "pending");
-        setStatus("st-fin",     finOK    ? "ok" : "pending");
-        setStatus("st-docs",    docsOK   ? "ok" : "pending");
-
-        // Textos condicionais
-        const descDados = document.getElementById("desc-dados");
-        if (descDados) {
-          descDados.textContent = isCompany
-            ? "Informe razão social/nome e CNPJ."
-            : "Informe seu documento ou complete nome público e LinkedIn.";
-        }
-        const descFin = document.getElementById("desc-fin");
-        if (descFin) {
-          descFin.textContent = isCompany
-            ? "Defina dados de cobrança (em breve)."
-            : "Informe sua chave Pix para receber.";
-        }
-
-        // Progresso
-        const total = 4;
-        const done = [dadosOK, termosOK, finOK, docsOK].filter(Boolean).length;
-        document.getElementById("actTotal")?.replaceChildren(String(total));
-        document.getElementById("actCount")?.replaceChildren(String(done));
-
-        // Ações (por enquanto placeholders)
-        document.getElementById("btn-dados")?.addEventListener("click", () => {
-          alert("Tela de dados do perfil (em breve).");
-        }, { once:true });
-
-        document.getElementById("btn-termos")?.addEventListener("click", async () => {
-          // MVP: aceitar termos direto (apenas para demonstração)
-          try {
-            const now = new Date().toISOString();
-            const upd = await sb.from("profiles").update({ accept_terms_at: now, terms_version: 1 }).eq("id", uid);
-            if (!upd.error) { await renderActivationChecklist(); }
-          } catch (e) { console.warn(e); }
-        }, { once:true });
-
-        document.getElementById("btn-fin")?.addEventListener("click", () => {
-          alert(isCompany ? "Configuração de cobrança (em breve)." : "Cadastro da chave Pix (em breve).");
-        }, { once:true });
-
-        document.getElementById("btn-docs")?.addEventListener("click", () => {
-          /* Em breve: upload + fila de revisão */
-        }, { once:true });
-      }
-    </script>
-
-    <!-- 5) Boot da página privada -->
-    <script>
-      (async () => {
-        const showBootError = (msg) => {
-          const box = document.getElementById("bootError");
-          if (!box) return;
-          box.innerHTML = `<b>Erro ao inicializar a app:</b><br><small>${msg}</small>`;
-          box.classList.remove("hide");
-        };
-
-        try {
-          // Garante sessão (se não tiver, redireciona p/ /index.html)
-          const session = await requireAuth();
-
-          // Alterna UI (mostra [data-auth], preenche #userEmail)
-          await applyAuthUI();
-
-          // Papel (se faltar, modal; se existir, atualiza rótulo)
-          await ensureRole();
-
-          // Checklist (somente leitura no MVP)
-          await renderActivationChecklist();
-
-          // Handlers de sair
-          const doLogout = async () => {
-            try { await logoutLocal(); } catch {}
-            location.href = "/index.html";
-          };
-          document.getElementById("btnOutTop")?.addEventListener("click", doLogout);
-          document.getElementById("btnOutMobile")?.addEventListener("click", doLogout);
-        } catch (e) {
-          console.error(e);
-          showBootError(e?.message || "Falha inesperada.");
-        }
-      })();
-    </script>
-
-    <!-- 6) Menu móvel -->
+    <!-- Menu móvel -->
     <script>
       (function () {
         const btn = document.querySelector(".menu-toggle");
         const mobile = document.querySelector(".mobile-menu");
         if (!btn || !mobile) return;
-
-        const open = () => {
-          document.body.classList.add("menu-open");
-          btn.classList.add("is-open");
-          btn.setAttribute("aria-expanded", "true");
-          mobile.setAttribute("aria-hidden", "false");
-        };
-        const close = () => {
-          document.body.classList.remove("menu-open");
-          btn.classList.remove("is-open");
-          btn.setAttribute("aria-expanded", "false");
-          mobile.setAttribute("aria-hidden", "true");
-        };
-        const toggle = () =>
-          document.body.classList.contains("menu-open") ? close() : open();
-
-        btn.addEventListener("click", toggle);
-        mobile.addEventListener("click", (e) => {
-          if (e.target.classList.contains("mm-link")) close();
-        });
+        const open = () => { document.body.classList.add("menu-open"); btn.classList.add("is-open"); btn.setAttribute("aria-expanded", "true"); mobile.setAttribute("aria-hidden", "false"); };
+        const close = () => { document.body.classList.remove("menu-open"); btn.classList.remove("is-open"); btn.setAttribute("aria-expanded", "false"); mobile.setAttribute("aria-hidden", "true"); };
+        btn.addEventListener("click", () => document.body.classList.contains("menu-open") ? close() : open());
+        mobile.addEventListener("click", (e) => { if (e.target.classList.contains("mm-link")) close(); });
         window.addEventListener("keyup", (e) => { if (e.key === "Escape") close(); });
         window.addEventListener("resize", () => { if (window.innerWidth > 900) close(); });
       })();
     </script>
 
-    <!-- 7) (Opcional) sombra sutil na topbar -->
+    <!-- Sombra sutil na topbar -->
     <script>
       (function () {
         const topbar = document.querySelector(".topbar");
         if (!topbar) return;
-        const onScroll = () =>
-          topbar.classList.toggle("is-scrolled", window.scrollY > 4);
-        onScroll();
-        window.addEventListener("scroll", onScroll, { passive: true });
+        const onScroll = () => topbar.classList.toggle("is-scrolled", window.scrollY > 4);
+        onScroll(); window.addEventListener("scroll", onScroll, { passive: true });
       })();
     </script>
-    <!-- ========================== /SCRIPTS ========================== -->
   </body>
 </html>

--- a/assets/css/activation.css
+++ b/assets/css/activation.css
@@ -1,23 +1,127 @@
-/* === Tweaks de legibilidade da tela de ativação =================== */
+/* ===== Modal genérico ===== */
+.modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(7,12,22,.6);z-index:50;padding:24px}
+.modal[aria-hidden="false"]{display:flex}
+body.modal-open{overflow:hidden}
 
-/* 1) Respiração do texto das descrições */
-.activation-item .desc { 
-  line-height: 1.55;
+/* ===== Checklist de ativação (base) ===== */
+.activation-card{max-width:980px;margin:28px auto}
+.activation-card .head{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:12px}
+.activation-title{font-weight:800;font-size:20px;line-height:1.35;color:#e8eefb}
+.activation-progress{font-size:15px;color:#cfe3ff}
+.activation-list{list-style:none;margin:0;padding:0;display:grid;gap:12px}
+.activation-item{display:flex;align-items:center;gap:12px;padding:14px 16px;border:1px solid rgba(255,255,255,.08);border-radius:14px;background:rgba(255,255,255,.03)}
+.activation-item .badge{min-width:28px;height:28px;border-radius:999px;display:flex;align-items:center;justify-content:center;font-weight:800;background:rgba(56,189,248,.12);color:#86d5ff;font-size:14px}
+.activation-item .info{flex:1}
+.activation-item .title{font-weight:700;color:#e8eefb;font-size:19.5px}
+.activation-item .desc{color:#d7e9ff;font-size:18.5px;line-height:1.5}
+.activation-item .status{font-size:16.5px;font-weight:700;padding:6px 10px;border-radius:999px;border:1px solid rgba(255,255,255,.12)}
+.st-ok{color:#bff5df;border-color:#2dd4bf}
+.st-pending{color:#ffe9b6;border-color:#fbbf24}
+.st-missing{color:#ffd1d1;border-color:#f87171}
+.btn.sm{height:40px;padding:0 14px;font-size:15px}
+.btn.sm:focus-visible,.activation-item .status:focus-visible{outline:2px solid #89c6ff;outline-offset:2px}
+@media (max-width:640px){
+  .activation-card .head{flex-direction:column;align-items:flex-start}
+  .activation-item{padding:16px}
+  .activation-item .badge{min-width:30px;height:30px;font-size:15px}
+  .activation-item .title{font-size:17px}
+  .activation-item .desc{font-size:15px}
+  .btn.sm{height:44px;padding:0 16px;font-size:16px}
+}
+.btn[disabled],.btn[aria-disabled="true"],.btn.is-disabled{opacity:.6;pointer-events:none;cursor:default}
+
+/* ===== Termos de uso — Tema claro só no modal ===== */
+#termsModal{
+  --tm-bg:#fff;           /* fundo */
+  --tm-fg:#111827;        /* texto */
+  --tm-muted:#4b5563;     /* ícones/detalhes */
+  --tm-border:#e5e7eb;    /* linhas */
+  --tm-surface:#f8fafc;   /* rodapé */
+  --tm-link:#1d4ed8;      /* links */
+  --tm-primary:#2563eb;   /* aceitar */
 }
 
-/* 2) Chip "Pendente" com contraste melhor */
-.activation-item .status{
-  background: #2c3240;  /* ligeiramente mais escuro que o fundo */
-  color: #ffd36e;        /* amarelo mais vivo */
-  font-weight: 700;
+/* Diálogo: largura, layout, cantos e overflow */
+#termsModal .modal-dialog{
+  background:var(--tm-bg); color:var(--tm-fg);
+  border:1px solid var(--tm-border); border-radius:16px;
+  box-shadow:0 24px 64px rgba(0,0,0,.18);
+  width:min(760px,94vw); max-height:90vh;
+  display:flex; flex-direction:column; overflow:hidden;
 }
 
-/* 3) Conforto no mobile para botões pequenos */
-@media (max-width: 640px){
-  .btn.sm { 
-    height: 44px; 
-    padding: 0 16px; 
-    font-size: 16px; 
-    width: 100%;
-  }
+/* Cabeçalho “sticky” */
+#termsModal .modal-header{
+  position:sticky; top:0; z-index:2;
+  display:flex; align-items:center; justify-content:center;
+  padding:14px 48px 14px 18px;
+  background:var(--tm-bg); border-bottom:1px solid var(--tm-border);
+  font-weight:800;
+}
+#termsModal .modal-header .icon{
+  position:absolute; top:8px; right:10px;
+  width:36px;height:36px; line-height:36px; font-size:22px;
+  border:0;border-radius:10px;background:transparent;color:var(--tm-muted);cursor:pointer;
+}
+#termsModal .modal-header .icon:hover{background:#f3f4f6;color:var(--tm-fg)}
+
+/* Área rolável do conteúdo */
+#termsModal .terms-card{flex:1; overflow:auto; padding:0 18px; background:var(--tm-bg)}
+#termsModal .terms-box{
+  background:#fff; color:#111827;
+  border:1px solid #e5e7eb; border-radius:8px;
+  padding:16px; max-height:none; overflow:visible;
+  scrollbar-gutter:stable;
+}
+#termsModal .terms-box > :first-child{margin-top:0!important}
+
+/* Hierarquia de texto do documento */
+#termsModal .terms-box h1{font-size:22px;font-weight:800;margin:6px 0 10px}
+#termsModal .terms-box h2{font-size:18px;font-weight:800;margin:14px 0 8px}
+#termsModal .terms-box h3{font-size:16px;font-weight:700;margin:12px 0 6px}
+#termsModal .terms-box p{margin:0 0 10px}
+#termsModal .terms-box ul,#termsModal .terms-box ol{margin:8px 0 12px;padding-left:22px}
+#termsModal .terms-box a{color:var(--tm-link);text-decoration:underline}
+#termsModal .terms-box::-webkit-scrollbar{width:10px}
+#termsModal .terms-box::-webkit-scrollbar-thumb{background:#d1d5db;border-radius:999px}
+
+/* Checkbox de concordância */
+#termsModal .agree{display:flex;align-items:center;gap:8px;margin:12px 0 8px}
+#termsModal .agree input{width:18px;height:18px}
+#termsModal .agree span{font-size:15px}
+
+/* Rodapé fixo */
+#termsModal .modal-actions{
+  position:sticky; bottom:0; z-index:2;
+  display:flex; align-items:center; gap:14px;
+  padding:15px 18px;
+  background:var(--tm-surface); border-top:1px solid var(--tm-border);
+}
+#termsModal .modal-actions .spacer{flex:1}
+
+/* Botões */
+#termsModal button{height:44px;border-radius:12px;font-weight:600}
+#termsModal #btnAcceptTerms{background:var(--tm-primary);border:1px solid var(--tm-primary);color:#fff}
+#termsModal #btnAcceptTerms:hover:not(:disabled){filter:brightness(.95)}
+#termsModal #btnAcceptTerms:disabled{background:#c7d2fe;border-color:#c7d2fe;color:#fff;opacity:.85;cursor:not-allowed}
+#termsModal .btn-cancel{background:#f3f4f6;border:1px solid var(--tm-border);color:var(--tm-fg)}
+
+/* Link “Baixar PDF” com aparência de âncora */
+#btnPrintTerms{
+  background:transparent;border:0;height:auto;padding:0;
+  color:var(--tm-link);text-decoration:underline;font-weight:600;cursor:pointer
+}
+#btnPrintTerms:hover{text-decoration:none;color:#1e40af}
+#btnPrintTerms:focus-visible{outline:2px solid #93c5fd;outline-offset:2px}
+#btnPrintTerms[disabled]{color:#9ca3af;text-decoration:none;cursor:not-allowed}
+
+/* ===== Impressão: só o conteúdo dos termos ===== */
+@media print{
+  body *{visibility:hidden!important}
+  #termsModal,#termsModal *{visibility:visible!important}
+  #termsModal{position:static!important;inset:auto!important;background:#fff!important}
+  #termsModal .modal-header,#termsModal .modal-actions{display:none!important}
+  #termsModal .modal-dialog{box-shadow:none!important;border:none!important;width:auto!important;max-width:none!important;margin:0!important;padding:0 24px!important}
+  #termsModal .terms-card{padding:0!important}
+  #termsModal .terms-box{border:0!important;padding:0!important}
 }

--- a/assets/js/activation.js
+++ b/assets/js/activation.js
@@ -1,0 +1,282 @@
+// /assets/js/activation.js — fluxo Termos (e-mail só no PDF)
+(function () {
+  const $ = (id) => document.getElementById(id);
+
+  // ==== CONFIG DOS TERMOS ====
+  const TERMS = {
+    version: 2,
+    locale: "pt-BR",
+    url: "/legal/terms/pt-BR/1/terms.html",
+  };
+
+  // estado
+  let uid = null;
+  let userEmail = null;
+  let profile = null;
+  let loadedTermsHash = null;
+  let termsRawHtml = "";
+  let scrolledToEnd = false;
+
+  document.addEventListener("DOMContentLoaded", initActivation);
+
+  async function initActivation() {
+    try {
+      const { data: s } = await sb.auth.getSession();
+      const session = s?.session ?? null;
+      uid = session?.user?.id ?? null;
+      userEmail = session?.user?.email ?? null;
+      if (!uid) return;
+
+      await refreshActivationStatus();
+      bindTermsUI();
+    } catch (e) {
+      console.warn("[activation] init error:", e);
+    }
+  }
+
+  // ===== Utils =====
+  async function sha256(text) {
+    const enc = new TextEncoder().encode(text);
+    const buf = await crypto.subtle.digest("SHA-256", enc);
+    return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  function disable(el, flag = true) {
+    if (!el) return;
+    el.disabled = !!flag;
+    el.setAttribute("aria-disabled", flag ? "true" : "false");
+  }
+  function setStatus(elId, state) {
+    const el = $(elId);
+    if (!el) return;
+    el.classList.remove("st-ok", "st-pending", "st-missing");
+    if (state === "ok") { el.classList.add("st-ok"); el.textContent = "Concluído"; }
+    else if (state === "pending") { el.classList.add("st-pending"); el.textContent = "Pendente"; }
+    else { el.classList.add("st-missing"); el.textContent = "Faltando"; }
+  }
+  function updateAcceptState() {
+    const chk = $("chkAgree");
+    const btnAccept = $("btnAcceptTerms");
+    disable(btnAccept, !(chk?.checked && loadedTermsHash && scrolledToEnd));
+  }
+
+  // ===== Checklist =====
+  async function refreshActivationStatus() {
+    const { data, error } = await sb
+      .from("profiles")
+      .select(
+        "id, role, company_name, document, display_name, linkedin_url, pix_key, accept_terms_at, terms_version"
+      )
+      .eq("id", uid)
+      .maybeSingle();
+
+    if (error) { console.warn("[activation] read profile error:", error); return; }
+    profile = data || {};
+
+    const role = profile?.role || null;
+    const isCompany = role === "company";
+
+    const dadosOK = isCompany
+      ? !!(profile?.company_name && profile?.document)
+      : !!(profile?.document || (profile?.display_name && profile?.linkedin_url));
+
+    const termosOK = !!profile?.accept_terms_at && Number(profile?.terms_version || 0) >= TERMS.version;
+    const finOK = isCompany ? false : !!profile?.pix_key; // MVP
+    const docsOK = false;
+
+    setStatus("st-dados", dadosOK ? "ok" : "pending");
+    setStatus("st-termos", termosOK ? "ok" : "pending");
+    setStatus("st-fin", finOK ? "ok" : "pending");
+    setStatus("st-docs", docsOK ? "ok" : "pending");
+
+    $("actTotal")?.replaceChildren("4");
+    $("actCount")?.replaceChildren(String([dadosOK, termosOK, finOK, docsOK].filter(Boolean).length));
+
+    // botão "Ler & aceitar"
+    disable($("btn-termos"), termosOK);
+  }
+
+  // ===== Modal =====
+  function bindTermsUI() {
+    const btnOpen   = $("btn-termos");
+    const modal     = $("termsModal");
+    const chk       = $("chkAgree");
+    const btnAccept = $("btnAcceptTerms");
+    const btnPrint  = $("btnPrintTerms");
+
+    if (!btnOpen || !modal || !chk || !btnAccept) return;
+
+    disable(btnPrint, true);
+
+    btnOpen.addEventListener("click", async () => {
+      openModal(modal);
+      await loadTermsIntoModal();
+    });
+
+    // fechar por [x] ou elementos com data-close="1"
+    modal.addEventListener("click", (e) => {
+      const t = e.target;
+      if (t instanceof HTMLElement && t.dataset.close === "1") closeModal(modal);
+    });
+
+    chk.addEventListener("change", updateAcceptState);
+
+    btnAccept.addEventListener("click", async () => {
+      if (!uid || !loadedTermsHash || !chk.checked || !scrolledToEnd) return;
+      disable(btnAccept, true);
+      try {
+        await persistTermsAcceptance();
+        closeModal(modal);
+        await refreshActivationStatus();
+      } catch (e) {
+        console.error("[activation] accept terms error:", e);
+        alert("Não foi possível salvar sua aceitação. Tente novamente.");
+        disable(btnAccept, false);
+      }
+    });
+
+    // imprimir / salvar PDF (janela branca)
+    btnPrint?.addEventListener("click", () => { printTermsAsPdf(); });
+
+    // ESC fecha
+    window.addEventListener("keyup", (e) => { if (e.key === "Escape") closeModal(modal); });
+  }
+
+  async function loadTermsIntoModal() {
+    loadedTermsHash = null;
+    termsRawHtml = "";
+    scrolledToEnd = false;
+
+    const box       = document.querySelector("#termsModal .terms-box");
+    const btnPrint  = $("btnPrintTerms");
+    const metaSpan  = $("termsMeta");   // linha de versão/data/idioma no rodapé
+    const hint      = $("scrollHint");  // se você estiver usando uma dica "role até o fim"
+
+    if (box) box.innerHTML = "<p>Carregando…</p>";
+    disable(btnPrint, true);
+    const agree = $("chkAgree"); if (agree) agree.checked = false;
+    updateAcceptState();
+    hint?.classList.remove("hide");
+
+    // meta SEM e-mail (só no PDF vamos incluir e-mail)
+    const now = new Date();
+    if (metaSpan) {
+      metaSpan.textContent =
+        `Versão ${TERMS.version} • Atualizado em ${now.toLocaleDateString("pt-BR")} • Idioma ${TERMS.locale}`;
+    }
+
+    try {
+      const res = await fetch(TERMS.url, { cache: "no-cache" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const html = await res.text();
+
+      termsRawHtml = html;
+      loadedTermsHash = await sha256(html);
+
+      if (box) {
+        box.innerHTML = html;
+
+        // compliance: precisa rolar até o fim
+        const checkEnd = () => {
+          if (!box) return;
+          const end = box.scrollTop + box.clientHeight >= box.scrollHeight - 8;
+          if (end && !scrolledToEnd) {
+            scrolledToEnd = true;
+            hint?.classList.add("hide");
+            updateAcceptState();
+          }
+        };
+        box.addEventListener("scroll", checkEnd, { passive: true });
+        requestAnimationFrame(checkEnd); // estado inicial
+      }
+
+      disable(btnPrint, false);
+      updateAcceptState();
+    } catch (e) {
+      console.warn("[activation] load terms error:", e);
+      loadedTermsHash = null;
+      termsRawHtml = "";
+      if (box) box.innerHTML =
+        '<p class="muted">Não foi possível carregar os Termos no momento. Tente novamente.</p>';
+    }
+  }
+
+  // === Impressão / "Salvar como PDF" (apenas aqui aparece o e-mail) ===
+  function printTermsAsPdf() {
+    if (!termsRawHtml) return;
+    try {
+      const w = window.open("", "_blank");
+      if (!w) { alert("Permita pop-ups para salvar o PDF."); return; }
+
+      const when = new Date().toLocaleString("pt-BR");
+      const css = `
+        html,body{background:#fff;color:#111;font:16px/1.55 system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;margin:0;padding:24px;}
+        h1{margin:0 0 8px;}
+        .meta{font-size:12px;color:#555;margin-bottom:12px;}
+        hr{border:0;border-top:1px solid #e5e7eb;margin:12px 0 20px;}
+        *{print-color-adjust:exact;-webkit-print-color-adjust:exact;}
+      `;
+
+      const emailLine = userEmail ? ` • Usuário ${userEmail}` : "";
+
+      w.document.open();
+      w.document.write(`<!doctype html>
+        <html lang="pt-BR">
+          <head>
+            <meta charset="utf-8">
+            <title>Termos de Uso — Bidly</title>
+            <style>${css}</style>
+          </head>
+          <body>
+            <h1>Termos de Uso — Bidly</h1>
+            <div class="meta">Versão ${TERMS.version} • Atualizado em ${when} • Idioma ${TERMS.locale}${emailLine}</div>
+            <hr>
+            ${termsRawHtml}
+          </body>
+        </html>`);
+      w.document.close();
+      w.focus();
+      setTimeout(() => { w.print(); w.close(); }, 300);
+    } catch (e) {
+      console.error("[activation] print error:", e);
+      alert("Não foi possível abrir a impressão.");
+    }
+  }
+
+  // grava aceitação
+  async function persistTermsAcceptance() {
+    const role = profile?.role ?? null;
+    const userAgent = navigator.userAgent ?? null;
+
+    const ins = await sb.from("terms_consent_events").insert({
+      user_id: uid,
+      role,
+      locale: TERMS.locale,
+      terms_version: TERMS.version,
+      terms_url: TERMS.url,
+      doc_hash: loadedTermsHash,
+      user_agent: userAgent,
+    });
+    if (ins.error) throw ins.error;
+
+    const now = new Date().toISOString();
+    const upd = await sb
+      .from("profiles")
+      .update({ accept_terms_at: now, terms_version: TERMS.version })
+      .eq("id", uid);
+    if (upd.error) throw upd.error;
+  }
+
+  function openModal(modal) {
+    modal.classList.remove("hide");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.classList.add("modal-open");
+  }
+  function closeModal(modal) {
+    modal.classList.add("hide");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("modal-open");
+    const chk = $("chkAgree");
+    if (chk) chk.checked = false;
+    disable($("btnAcceptTerms"), true);
+  }
+})();

--- a/legal/terms/pt-BR/1/terms.html
+++ b/legal/terms/pt-BR/1/terms.html
@@ -1,0 +1,40 @@
+<h2>Termos de Uso — Bidly</h2>
+<p><small>Versão 1 • Atualizado em 05/10/2025</small></p>
+
+<h3>1. Introdução</h3>
+<p>Ao utilizar a Bidly, você concorda com estes Termos...</p>
+
+<h3>2. Elegibilidade</h3>
+<p>Você declara ser maior de 18 anos e possuir capacidade civil...</p>
+
+<h3>3. Regras de uso</h3>
+<ul>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>...</li>
+</ul>
+
+<h3>4. Responsabilidades</h3>
+<p>...</p>
+
+<h3>5. Privacidade</h3>
+<p>Consulte nossa Política de Privacidade...</p>
+
+<h3>6. Pagamentos</h3>
+<p>...</p>
+
+<h3>7. Alterações</h3>
+<p>Podemos alterar estes Termos; quando isso ocorrer, uma nova versão será apresentada para aceite.</p>
+
+<h3>8. Contato</h3>
+<p>Suporte: suporte@bidly.com</p>

--- a/legal/terms/pt-BR/2/terms.html
+++ b/legal/terms/pt-BR/2/terms.html
@@ -1,0 +1,30 @@
+<h2>Termos de Uso — Bidly - VIXIIIIII</h2>
+<p><small>Versão 1 • Atualizado em 05/10/2025</small></p>
+
+<h3>1. Introdução</h3>
+<p>Ao utilizar a Bidly, você concorda com estes Termos...</p>
+
+<h3>2. Elegibilidade</h3>
+<p>Você declara ser maior de 18 anos e possuir capacidade civil...</p>
+
+<h3>3. Regras de uso</h3>
+<ul>
+  <li>Não publicar informações falsas;</li>
+  <li>Respeitar a privacidade e a legislação aplicável;</li>
+  <li>...</li>
+</ul>
+
+<h3>4. Responsabilidades</h3>
+<p>...</p>
+
+<h3>5. Privacidade</h3>
+<p>Consulte nossa Política de Privacidade...</p>
+
+<h3>6. Pagamentos</h3>
+<p>...</p>
+
+<h3>7. Alterações</h3>
+<p>Podemos alterar estes Termos; quando isso ocorrer, uma nova versão será apresentada para aceite.</p>
+
+<h3>8. Contato</h3>
+<p>Suporte: suporte@bidly.com</p>


### PR DESCRIPTION
Modal claro/acessível; aceite só após rolar ao fim + checkbox.

Auditoria em terms_consent_events e update de profiles.accept_terms_at/terms_version.

Botão Salvar PDF com carimbo (versão/data/idioma) e e-mail do usuário.

Revalida automaticamente quando TERMS.version sobe.