### PR TITLE
chore: ajustes finais no fluxo de dados da organização (PJ/CPF)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
-  
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -8,11 +7,12 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/assets/css/base.css" />
     <link rel="stylesheet" href="/assets/css/app.css" />
-    <link rel="stylesheet" href="/assets/css/activation.css?v=1" />
+    <link rel="stylesheet" href="/assets/css/activation.css?v=2" />
     <style>
       .hide { display: none !important; }
     </style>
   </head>
+
   <body class="wrap has-topbar">
     <!-- ====================== TOPBAR ====================== -->
     <header class="topbar">
@@ -73,7 +73,7 @@
             <div class="desc" id="desc-dados">Complete as informações básicas para operar.</div>
           </div>
           <span class="status st-pending" id="st-dados">Pendente</span>
-          <button class="btn outline sm" id="btnProfile">Preencher</button>
+          <button class="btn outline sm" id="btn-dados">Preencher</button>
         </li>
 
         <!-- 2) Termos -->
@@ -115,7 +115,6 @@
     <section id="bootError" class="card card-pad hide" style="max-width:980px; margin:16px auto"></section>
 
     <!-- Modal: escolher papel (se não houver role) -->
-    
     <div id="modalRole" class="modal hide" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalRoleTitle">
       <div class="modal__box">
         <h3 id="modalRoleTitle" style="margin:0 0 8px">Como você quer usar a Bidly?</h3>
@@ -127,66 +126,78 @@
       </div>
     </div>
 
+    <!-- ===== Modal: Dados da organização (tema claro) ===== -->
+    <div id="orgModal" class="modal hide" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="modal-dialog" role="document" aria-labelledby="orgTitle">
+        <div class="modal-header">
+          <h3 id="orgTitle">Dados da organização</h3>
+          <button class="icon" id="orgClose" aria-label="Fechar" title="Fechar">×</button>
+        </div>
 
-    
-                <!-- ===== Modal: Termos de uso ===== -->
-      <div id="termsModal" class="modal hide" aria-hidden="true" role="dialog" aria-modal="true">
-        <div class="modal-dialog" role="document" aria-labelledby="termsTitle">
-          <div class="modal-header">
-            <h3 id="termsTitle">Termos de uso</h3>
-            <button class="icon" data-close="1" aria-label="Fechar" title="Fechar">×</button>
-          </div>
-
-          <div class="terms-card">
-            <div class="terms-box" id="termsBox">
-              <!-- o HTML dos termos é carregado aqui via JS -->
-            </div>
-
-            <label class="agree" for="chkAgree">
-              <input type="checkbox" id="chkAgree" />
-              <span>Li e concordo com os termos de uso.</span>
+        <form id="orgForm" class="org-card" autocomplete="off">
+          <!-- Tipo de entidade -->
+          <div class="org-type">
+            <label class="pill">
+              <input type="radio" name="org_type" value="PJ" checked />
+              <span>Pessoa Jurídica (CNPJ)</span>
             </label>
-
-            <small id="scrollHint" class="muted">Role até o fim do documento para habilitar “Aceitar”.</small>
+            <label class="pill">
+              <input type="radio" name="org_type" value="PF" />
+              <span>Pessoa Física (CPF)</span>
+            </label>
           </div>
+
+          <!-- Campos dinâmicos -->
+          <div id="orgFields" class="org-fields"></div>
 
           <div class="modal-actions">
-            <span id="termsMeta" class="meta"></span>
-            <button id="btnPrintTerms" type="button" class="btn link">Salvar PDF</button>
+            <small id="orgHint" class="meta"></small>
             <div class="spacer"></div>
-            <button type="button" class="btn ghost btn-cancel" data-close="1">Cancelar</button>
-            <button id="btnAcceptTerms" type="button" class="btn primary" disabled>Aceitar</button>
+            <button type="button" class="btn ghost" id="btnOrgCancel">Cancelar</button>
+            <button type="submit" class="btn primary" id="btnOrgSubmit">Enviar para análise</button>
           </div>
+        </form>
+      </div>
+    </div>
+    <!-- ===== /Modal ===== -->
+
+    <!-- ===== Modal: Termos de uso ===== -->
+    <div id="termsModal" class="modal hide" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="modal-dialog" role="document" aria-labelledby="termsTitle">
+        <div class="modal-header">
+          <h3 id="termsTitle">Termos de uso</h3>
+          <button class="icon" data-close="1" aria-label="Fechar" title="Fechar">×</button>
+        </div>
+
+        <div class="terms-card">
+          <div class="terms-box" id="termsBox">
+            <!-- o HTML dos termos é carregado aqui via JS -->
+          </div>
+
+          <label class="agree" for="chkAgree">
+            <input type="checkbox" id="chkAgree" />
+            <span>Li e concordo com os termos de uso.</span>
+          </label>
+
+          <small id="scrollHint" class="muted">Role até o fim do documento para habilitar “Aceitar”.</small>
+        </div>
+
+        <div class="modal-actions">
+          <span id="termsMeta" class="meta"></span>
+          <button id="btnPrintTerms" type="button" class="btn link">Salvar PDF</button>
+          <div class="spacer"></div>
+          <button type="button" class="btn ghost btn-cancel" data-close="1">Cancelar</button>
+          <button id="btnAcceptTerms" type="button" class="btn primary" disabled>Aceitar</button>
         </div>
       </div>
-      <!-- ===== /Modal ===== -->
-
-
-
-        <!-- 🔹 Modal: Dados do Perfil -->
-        <div id="modalProfile" class="modal hidden">
-          <div class="modal-content">
-            <h2>Dados do Perfil</h2>
-            <form id="formProfile">
-              <!-- Campos dinâmicos conforme o role -->
-              <div id="profileFields"></div>
-
-              <div class="modal-actions">
-                <button type="button" id="btnCancelProfile">Cancelar</button>
-                <button type="submit" id="btnSaveProfile">Salvar</button>
-              </div>
-            </form>
-          </div>
-        </div>
-
-
-
+    </div>
+    <!-- ===== /Modal ===== -->
 
     <!-- ============================ SCRIPTS ============================ -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.46.1/dist/umd/supabase.js"></script>
     <script src="/assets/js/supa.js?v=1"></script>
-    <script src="/assets/js/app.js?v=ROLE3"></script>
-    <script src="/assets/js/activation.js?v=1"></script>
+    <script src="/assets/js/app.js?v=ORG3"></script>
+    <script src="/assets/js/activation.js?v=2"></script>
 
     <!-- Menu móvel -->
     <script>
@@ -212,33 +223,5 @@
         onScroll(); window.addEventListener("scroll", onScroll, { passive: true });
       })();
     </script>
-
-
-
-<style>
-  .modal.hidden { display: none; }
-  .modal {
-    position: fixed; inset: 0;
-    display: flex; align-items: center; justify-content: center;
-    background: rgba(0,0,0,0.5); z-index: 9999;
-  }
-  .modal-content {
-    background: #101522; padding: 24px; border-radius: 12px;
-    width: 100%; max-width: 420px; color: #fff;
-  }
-  .modal-content h2 { margin-bottom: 16px; }
-  .modal-content input {
-    width: 100%; padding: 8px; margin: 6px 0 12px;
-    border-radius: 6px; border: 1px solid #333; background: #1c2233; color: #fff;
-  }
-  .modal-actions { display: flex; justify-content: flex-end; gap: 12px; }
-  .modal-actions button { padding: 8px 16px; border: none; border-radius: 6px; cursor: pointer; }
-  #btnCancelProfile { background: #444; color: #ccc; }
-  #btnSaveProfile { background: #3b82f6; color: white; }
-</style>
-
-
-
-
   </body>
 </html>

--- a/assets/css/activation.css
+++ b/assets/css/activation.css
@@ -145,3 +145,58 @@ body.modal-open{overflow:hidden}
   #termsModal{ --overlay-pad-y: calc(32px + env(safe-area-inset-top)); }
   #termsModal .modal-dialog{max-height: calc(100vh - (var(--overlay-pad-y) * 2));}
 }
+
+
+/* ===== Modal "Dados da organização" (tema claro, igual aos Termos) ===== */
+#orgModal{
+  --tm-bg:#fff; --tm-fg:#111827; --tm-muted:#4b5563; --tm-border:#e5e7eb;
+  --tm-surface:#f8fafc; --tm-link:#1d4ed8; --tm-primary:#2563eb;
+  --overlay-pad-y: calc(48px + env(safe-area-inset-top));
+  padding: var(--overlay-pad-y) 24px;
+}
+#orgModal .modal-dialog{
+  background:var(--tm-bg); color:var(--tm-fg);
+  border:1px solid var(--tm-border); border-radius:16px;
+  box-shadow:0 24px 64px rgba(0,0,0,.18);
+  width:min(760px,94vw);
+  max-height: calc(100vh - (var(--overlay-pad-y) * 2));
+  display:flex; flex-direction:column; overflow:hidden;
+}
+#orgModal .modal-header{
+  position:sticky; top:0; z-index:2;
+  display:flex; align-items:center; justify-content:center;
+  padding:14px 48px 14px 18px;
+  background:var(--tm-bg); border-bottom:1px solid var(--tm-border);
+  font-weight:800;
+}
+#orgModal .modal-header .icon{
+  position:absolute; top:8px; right:10px; width:36px;height:36px; line-height:36px;
+  font-size:22px; border:0;border-radius:10px;background:transparent;color:var(--tm-muted);cursor:pointer;
+}
+#orgModal .modal-header .icon:hover{background:#f3f4f6;color:var(--tm-fg)}
+
+#orgModal .org-card{flex:1; overflow:auto; padding:12px 18px 0; background:var(--tm-bg)}
+#orgModal .org-fields label{font-weight:600; display:block; margin:12px 0 6px}
+#orgModal .org-fields input, #orgModal .org-fields select{
+  width:100%; height:44px; border-radius:10px; border:1px solid var(--tm-border);
+  background:#fff; color:#111827; padding:0 12px; outline:none;
+}
+#orgModal .org-fields .row{display:grid; grid-template-columns:1fr 1fr; gap:10px}
+@media (max-width:640px){ #orgModal .org-fields .row{grid-template-columns:1fr} }
+
+#orgModal .org-type{display:flex; gap:10px; margin:6px 0 8px}
+#orgModal .org-type .pill{display:flex; align-items:center; gap:8px; padding:8px 12px; border:1px solid var(--tm-border); border-radius:999px; background:#fff; cursor:pointer}
+#orgModal .org-type input{width:18px;height:18px}
+
+#orgModal .modal-actions{
+  position:sticky; bottom:0; z-index:2; display:flex; align-items:center; gap:14px;
+  padding:15px 18px; background:var(--tm-surface); border-top:1px solid var(--tm-border);
+}
+#orgModal .modal-actions .spacer{flex:1}
+#orgModal .btn.primary{background:var(--tm-primary);border:1px solid var(--tm-primary);color:#fff}
+#orgModal .btn.primary:disabled{opacity:.7; cursor:not-allowed}
+
+/* Mensagens de erro simples */
+#orgModal .err{color:#b91c1c; font-size:13.5px; margin-top:4px}
+
+/* Acessibilidade/impressão seguem o padrão dos termos (não precisa duplicar) */

--- a/assets/js/activation.js
+++ b/assets/js/activation.js
@@ -1,4 +1,4 @@
-// /assets/js/activation.js — fluxo Termos (e-mail só no PDF)
+// /assets/js/activation.js — Checklist + Termos (unificado)
 (function () {
   const $ = (id) => document.getElementById(id);
 
@@ -9,7 +9,7 @@
     url: "/legal/terms/pt-BR/1/terms.html",
   };
 
-  // estado
+  // --- estado global deste módulo ---
   let uid = null;
   let userEmail = null;
   let profile = null;
@@ -27,14 +27,14 @@
       userEmail = session?.user?.email ?? null;
       if (!uid) return;
 
-      await refreshActivationStatus();
-      bindTermsUI();
+      await renderChecklist(); // 1ª pintura
+      bindTermsUI();           // liga o modal dos termos
     } catch (e) {
       console.warn("[activation] init error:", e);
     }
   }
 
-  // ===== Utils =====
+  // ======= Utils =======
   async function sha256(text) {
     const enc = new TextEncoder().encode(text);
     const buf = await crypto.subtle.digest("SHA-256", enc);
@@ -44,14 +44,13 @@
     if (!el) return;
     el.disabled = !!flag;
     el.setAttribute("aria-disabled", flag ? "true" : "false");
+    el.classList.toggle("is-disabled", !!flag);
   }
-  function setStatus(elId, state) {
-    const el = $(elId);
+  function setStatusPill(el, text, cls) {
     if (!el) return;
+    el.textContent = text;
     el.classList.remove("st-ok", "st-pending", "st-missing");
-    if (state === "ok") { el.classList.add("st-ok"); el.textContent = "Concluído"; }
-    else if (state === "pending") { el.classList.add("st-pending"); el.textContent = "Pendente"; }
-    else { el.classList.add("st-missing"); el.textContent = "Faltando"; }
+    if (cls) el.classList.add(cls);
   }
   function updateAcceptState() {
     const chk = $("chkAgree");
@@ -59,43 +58,102 @@
     disable(btnAccept, !(chk?.checked && loadedTermsHash && scrolledToEnd));
   }
 
-  // ===== Checklist =====
-  async function refreshActivationStatus() {
-    const { data, error } = await sb
-      .from("profiles")
-      .select(
-        "id, role, company_name, document, display_name, linkedin_url, pix_key, accept_terms_at, terms_version"
-      )
-      .eq("id", uid)
-      .maybeSingle();
+  // ======= Lógica de UI p/ “Dados do perfil” =======
+  function computeProfileUI(p) {
+    // Campos novos
+    const status = (p?.status_profile || "").toLowerCase();          // "aprovado" | "em_analise" | "reprovado" | ""
+    const approval = (p?.org_approval_status || "").toLowerCase();   // "aguardando" | "aprovado" | "reprovado" | ""
+    const done = !!p?.checklist_profile_done;
 
-    if (error) { console.warn("[activation] read profile error:", error); return; }
-    profile = data || {};
+    const out = {
+      statusPill: { text: "Pendente", cls: "st-pending" },
+      button: { label: "Preencher", disabled: false },
+      isDone: false,
+    };
 
-    const role = profile?.role || null;
-    const isCompany = role === "company";
+    if (status === "aprovado" || approval === "aprovado" || done) {
+      out.statusPill = { text: "Concluído", cls: "st-ok" };
+      out.button = { label: "Editar", disabled: false };
+      out.isDone = true;
+      return out;
+    }
 
-    const dadosOK = isCompany
-      ? !!(profile?.company_name && profile?.document)
-      : !!(profile?.document || (profile?.display_name && profile?.linkedin_url));
+    if (status === "em_analise" || approval === "aguardando") {
+      out.statusPill = { text: "Em análise", cls: "st-pending" };
+      out.button = { label: "Ver dados", disabled: true }; // conforme alinhado
+      return out;
+    }
 
-    const termosOK = !!profile?.accept_terms_at && Number(profile?.terms_version || 0) >= TERMS.version;
-    const finOK = isCompany ? false : !!profile?.pix_key; // MVP
-    const docsOK = false;
+    if (status === "reprovado" || approval === "reprovado") {
+      out.statusPill = { text: "Pendente", cls: "st-pending" };
+      out.button = { label: "Corrigir", disabled: false };
+      return out;
+    }
 
-    setStatus("st-dados", dadosOK ? "ok" : "pending");
-    setStatus("st-termos", termosOK ? "ok" : "pending");
-    setStatus("st-fin", finOK ? "ok" : "pending");
-    setStatus("st-docs", docsOK ? "ok" : "pending");
-
-    $("actTotal")?.replaceChildren("4");
-    $("actCount")?.replaceChildren(String([dadosOK, termosOK, finOK, docsOK].filter(Boolean).length));
-
-    // botão "Ler & aceitar"
-    disable($("btn-termos"), termosOK);
+    // fallback mantém Pendente/Preencher
+    return out;
   }
 
-  // ===== Modal =====
+  // ======= CHECKLIST (exposto globalmente) =======
+  async function renderChecklist() {
+    try {
+      // Garantir client/sessão
+      const { data: s } = await sb.auth.getSession();
+      const session = s?.session ?? null;
+      uid = session?.user?.id ?? uid;
+      userEmail = session?.user?.email ?? userEmail;
+      if (!uid) return;
+
+      // Buscamos todos os campos que o checklist usa agora
+      const { data, error } = await sb
+        .from("profiles")
+        .select(`
+          id, role,
+          status_profile, org_approval_status, checklist_profile_done,
+          accept_terms_at, terms_version
+        `)
+        .eq("id", uid)
+        .maybeSingle();
+
+      if (error) {
+        console.warn("[checklist] read profile error:", error);
+        return;
+      }
+      profile = data || {};
+
+      // 1) Dados do perfil (novo fluxo)
+      const ui = computeProfileUI(profile);
+      setStatusPill($("st-dados"), ui.statusPill.text, ui.statusPill.cls);
+      const btnDados = $("btnProfile") || $("btn-dados");
+      if (btnDados) {
+        btnDados.textContent = ui.button.label;
+        disable(btnDados, ui.button.disabled);
+      }
+
+      // 2) Termos (mantém lógica antiga)
+      const termosOK = !!profile?.accept_terms_at && Number(profile?.terms_version || 0) >= TERMS.version;
+      setStatusPill($("st-termos"), termosOK ? "Concluído" : "Pendente", termosOK ? "st-ok" : "st-pending");
+      disable($("btn-termos"), termosOK);
+
+      // 3) Financeiro (por enquanto continua pendente; será tratado na próxima etapa)
+      setStatusPill($("st-fin"), "Pendente", "st-pending");
+
+      // 4) Documentos (em breve)
+      setStatusPill($("st-docs"), "Pendente", "st-pending");
+
+      // Contador simples (apenas dados + termos contam por enquanto)
+      const doneCount = (ui.isDone ? 1 : 0) + (termosOK ? 1 : 0);
+      $("actTotal")?.replaceChildren("4");
+      $("actCount")?.replaceChildren(String(doneCount));
+    } catch (e) {
+      console.warn("[checklist] exceção:", e);
+    }
+  }
+
+  // Torna público (o app.js chama após salvar dados)
+  window.renderChecklist = renderChecklist;
+
+  // ======= TERMO DE USO (mantido) =======
   function bindTermsUI() {
     const btnOpen   = $("btn-termos");
     const modal     = $("termsModal");
@@ -126,7 +184,7 @@
       try {
         await persistTermsAcceptance();
         closeModal(modal);
-        await refreshActivationStatus();
+        await renderChecklist(); // atualiza o item "Termos"
       } catch (e) {
         console.error("[activation] accept terms error:", e);
         alert("Não foi possível salvar sua aceitação. Tente novamente.");
@@ -148,8 +206,8 @@
 
     const box       = document.querySelector("#termsModal .terms-box");
     const btnPrint  = $("btnPrintTerms");
-    const metaSpan  = $("termsMeta");   // linha de versão/data/idioma no rodapé
-    const hint      = $("scrollHint");  // se você estiver usando uma dica "role até o fim"
+    const metaSpan  = $("termsMeta");
+    const hint      = $("scrollHint");
 
     if (box) box.innerHTML = "<p>Carregando…</p>";
     disable(btnPrint, true);
@@ -157,7 +215,6 @@
     updateAcceptState();
     hint?.classList.remove("hide");
 
-    // meta SEM e-mail (só no PDF vamos incluir e-mail)
     const now = new Date();
     if (metaSpan) {
       metaSpan.textContent =
@@ -175,7 +232,6 @@
       if (box) {
         box.innerHTML = html;
 
-        // compliance: precisa rolar até o fim
         const checkEnd = () => {
           if (!box) return;
           const end = box.scrollTop + box.clientHeight >= box.scrollHeight - 8;
@@ -186,7 +242,7 @@
           }
         };
         box.addEventListener("scroll", checkEnd, { passive: true });
-        requestAnimationFrame(checkEnd); // estado inicial
+        requestAnimationFrame(checkEnd);
       }
 
       disable(btnPrint, false);
@@ -200,7 +256,6 @@
     }
   }
 
-  // === Impressão / "Salvar como PDF" (apenas aqui aparece o e-mail) ===
   function printTermsAsPdf() {
     if (!termsRawHtml) return;
     try {
@@ -242,7 +297,6 @@
     }
   }
 
-  // grava aceitação
   async function persistTermsAcceptance() {
     const role = profile?.role ?? null;
     const userAgent = navigator.userAgent ?? null;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,278 +1,376 @@
-// /assets/js/app.js — robusto c/ auto-cura de sessão e logout hard
+// /assets/js/app.js — robusto c/ auto-cura + modal claro de Organização (PJ/CPF) + escolha/lock por role
 (function () {
   const $ = (id) => document.getElementById(id);
 
-  // 🔒 Pré-hide do modal de papel (evita flash antes da checagem assíncrona)
-  try {
-    const __mr = document.getElementById("modalRole");
-    if (__mr) {
-      __mr.classList.add("hide");
-      __mr.setAttribute("aria-hidden", "true");
-    }
-  } catch {}
-
   document.addEventListener("DOMContentLoaded", boot);
 
-  // -------- Logout hard (limpa tudo e encerra sessão em todas as abas) --------
-  async function hardSignOut({ redirect = true } = {}) {
-    try {
-      await sb?.auth?.signOut?.({ scope: "global" });
-    } catch (e) {
-      console.warn("[auth] signOut falhou (ok continuar):", e);
-    }
+  // ---------- Utils simples ----------
+  function show(el) { el?.classList.remove("hide"); el?.setAttribute?.("aria-hidden", "false"); }
+  function hide(el) { el?.classList.add("hide"); el?.setAttribute?.("aria-hidden", "true"); }
 
+  // ---------- Logout hard ----------
+  async function hardSignOut({ redirect = true } = {}) {
+    try { await sb?.auth?.signOut?.({ scope: "global" }); } catch (e) { console.warn("[auth] signOut falhou:", e); }
     try {
       Object.keys(localStorage)
         .filter((k) => /^sb-.*-auth-token$/.test(k) || k.startsWith("supabase"))
         .forEach((k) => localStorage.removeItem(k));
     } catch {}
-
     try {
       if ("caches" in window) {
         const keys = await caches.keys();
         await Promise.all(keys.map((k) => caches.delete(k)));
       }
-    } catch (e) {
-      console.warn("[auth] limpar caches: ignorado", e);
-    }
-
+    } catch (e) { console.warn("[auth] limpar caches:", e); }
     if (redirect) location.href = "/index.html";
   }
-
   window.hardSignOut = hardSignOut;
 
-  // -------- Verificação segura da sessão (auto-cura) --------
+  // ---------- Sessão segura ----------
   async function safeInitAuth() {
     try {
       const { data, error } = await sb.auth.getSession();
       if (error) throw error;
-
       const session = data?.session ?? null;
-      if (!session) {
-        location.href = "/index.html";
-        return null;
-      }
+      if (!session) { location.href = "/index.html"; return null; }
 
       const uid = session.user?.id;
       const ping = await sb.from("profiles").select("id").eq("id", uid).limit(1);
-
-      const unauthorized =
-        ping.error &&
-        (ping.error.status === 401 ||
-          ping.error.status === 403 ||
-          /jwt|token/i.test(ping.error.message || ""));
-
-      if (unauthorized) {
-        console.warn("[auth] token inválido/expirado -> hardSignOut()");
-        await hardSignOut({ redirect: true });
-        return null;
-      }
-
+      const unauthorized = ping.error && (ping.error.status === 401 || ping.error.status === 403 || /jwt|token/i.test(ping.error.message || ""));
+      if (unauthorized) { await hardSignOut({ redirect: true }); return null; }
       return session;
     } catch (e) {
-      console.warn("[auth] safeInitAuth falhou, limpando sessão:", e);
+      console.warn("[auth] safeInitAuth:", e);
       await hardSignOut({ redirect: true });
       return null;
     }
   }
 
-  // -------- Boot do app --------
+  // ---------- Boot ----------
   async function boot() {
     try {
-      if (new URLSearchParams(location.search).get("logout") === "1") {
-        await hardSignOut();
-        return;
-      }
+      if (new URLSearchParams(location.search).get("logout") === "1") { await hardSignOut(); return; }
 
       await connectSupabase();
+
       const session = await safeInitAuth();
       if (!session) return;
 
-      const email = session.user?.email || "—";
-      $("userEmail")?.replaceChildren(email);
+      $("userEmail")?.replaceChildren(session.user?.email || "—");
+      document.querySelectorAll("[data-auth]").forEach((el) => { el.classList.remove("hide"); el.removeAttribute("aria-hidden"); });
 
-      document.querySelectorAll("[data-auth]").forEach((el) => {
-        el.classList.remove("hide");
-        el.removeAttribute("aria-hidden");
-      });
-
+      // Sair
       const btnOut = $("btnOutTop") || $("btnSignOut");
-      if (btnOut) {
-        btnOut.addEventListener("click", async (ev) => {
-          ev.preventDefault();
-          await hardSignOut();
-        });
-      }
+      btnOut?.addEventListener("click", async (ev) => { ev.preventDefault(); await hardSignOut(); });
 
-      // 6) Exibe papel no topo
       await paintUserRole(session);
 
-      // 6.1) Corrige bug: não exibir modalRole se o perfil já tem role
-      try {
-        const uid = session.user?.id;
-        if (uid) {
-          const { data: prof, error: e } = await sb
-            .from("profiles")
-            .select("role")
-            .eq("id", uid)
-            .maybeSingle();
+      // Wire modal "Escolher perfil"
+      wireRoleChooser(session);
 
-          if (!e) {
-            const role = prof?.role;
-            const modalRole = document.getElementById("modalRole");
-            if (modalRole) {
-              if (role) {
-                modalRole.classList.add("hide");
-                modalRole.setAttribute("aria-hidden", "true");
-              } else {
-                modalRole.classList.remove("hide");
-                modalRole.setAttribute("aria-hidden", "false");
-              }
-            }
-          }
-        }
-      } catch (err) {
-        console.warn("[modalRole-check] erro ao verificar role:", err);
-      }
+      // Mostrar/ocultar modalRole de acordo com a existência do role
+      await toggleRoleModalByProfile(session);
 
-      // 7) Sair em outra aba → logout global
-      sb.auth.onAuthStateChange((evt) => {
-        if (evt === "SIGNED_OUT") location.href = "/index.html";
-      });
+      // Reagir a logout em outra aba
+      sb.auth.onAuthStateChange((evt) => { if (evt === "SIGNED_OUT") location.href = "/index.html"; });
 
-      // 🔹 Inicializa módulo de perfil (dados)
-      bindProfileButton();
+      // Botão "Dados do perfil" (id=btn-dados)
+      const btnDados = $("btn-dados");
+      btnDados?.addEventListener("click", (ev) => { ev.preventDefault(); openOrgModal(); });
+      if (!btnDados) console.warn("⚠️ botão de perfil não encontrado (id=btn-dados)");
+
+      // Modal claro de organização
+      wireOrgForm();
+      window.addEventListener("keyup", (e) => { if (e.key === "Escape") closeOrgModal(); });
+
     } catch (e) {
       console.error("[app] boot error:", e);
       alert(e?.message || String(e));
     }
   }
 
-  // -------- UI: exibir papel do usuário --------
+  // ---------- Papel no topo ----------
   async function paintUserRole(session) {
     const out = $("userRoleText");
-    const setRoleText = (label) => {
-      if (out) out.textContent = " • Perfil: " + label;
-    };
-
+    const setRoleText = (label) => { if (out) out.textContent = " • Perfil: " + label; };
     try {
       const uid = session?.user?.id;
-      if (!uid) {
-        setRoleText("—");
-        return;
-      }
-
-      let { data, error } = await sb
-        .from("profiles")
-        .select("role")
-        .eq("id", uid)
-        .limit(1);
-
-      console.log("[role] by id ->", { data, error });
-
+      if (!uid) { setRoleText("—"); return; }
+      let { data } = await sb.from("profiles").select("role").eq("id", uid).limit(1);
       let role = Array.isArray(data) && data.length ? data[0]?.role : null;
-
       if (!role) {
-        const r2 = await sb
-          .from("profiles")
-          .select("role")
-          .eq("user_id", uid)
-          .limit(1);
-
-        console.log("[role] by user_id ->", { data: r2.data, error: r2.error });
+        const r2 = await sb.from("profiles").select("role").eq("user_id", uid).limit(1);
         role = Array.isArray(r2.data) && r2.data.length ? r2.data[0]?.role : null;
       }
-
       const isVendor = role === "vendor" || role === "supplier";
-      const label =
-        role === "company" ? "Empresa" : isVendor ? "Fornecedor" : "—";
+      setRoleText(role === "company" ? "Empresa" : isVendor ? "Fornecedor" : "—");
+    } catch (e) { console.warn("[role] erro:", e); setRoleText("—"); }
+  }
 
-      console.log("[role] uid=", uid, "role=", role, "label=", label);
-      setRoleText(label);
+  // ==========================================================
+  // Escolha de perfil (modalRole) — grava role e abre dados
+  // ==========================================================
+  function wireRoleChooser(session) {
+    const modalRole   = $("modalRole");
+    const btnCompany  = $("btnRoleCompany");
+    const btnVendor   = $("btnRoleVendor");
+    if (!modalRole || !btnCompany || !btnVendor) return;
+    if (modalRole.dataset.bound === "1") return;
+    modalRole.dataset.bound = "1";
+
+    const saveRole = async (role) => {
+      try {
+        const uid = session?.user?.id;
+        if (!uid) return;
+        btnCompany.disabled = true;
+        btnVendor.disabled = true;
+
+        const { error } = await sb.from("profiles").update({ role }).eq("id", uid);
+        if (error) throw error;
+
+        // Atualiza UI e segue para os dados
+        await paintUserRole(session);
+        hide(modalRole);
+        try { await openOrgModal(); } catch {}
+      } catch (e) {
+        console.warn("[role] update error:", e);
+        alert("Não foi possível salvar seu perfil. Tente novamente.");
+      } finally {
+        btnCompany.disabled = false;
+        btnVendor.disabled = false;
+      }
+    };
+
+    btnCompany.addEventListener("click", () => saveRole("company"));
+    btnVendor .addEventListener("click", () => saveRole("vendor"));
+  }
+
+  async function toggleRoleModalByProfile(session) {
+    try {
+      const uid = session.user?.id;
+      if (!uid) return;
+      const { data: prof } = await sb.from("profiles").select("role").eq("id", uid).maybeSingle();
+      const modalRole = $("modalRole");
+      if (!modalRole) return;
+      if (prof?.role) hide(modalRole);
+      else show(modalRole);
     } catch (e) {
-      console.warn("[role] erro ao obter role:", e);
-      setRoleText("—");
+      console.warn("[modalRole-check] erro:", e);
     }
   }
 
   // ==========================================================
-  // 🔹 MÓDULO NOVO — “Dados do Perfil” (Empresa / Fornecedor)
+  // Modal claro: Organização (PJ/CPF): lock por role + prefill
   // ==========================================================
-  async function openProfileModal() {
-    const modal = $("modalProfile");
-    const fields = $("profileFields");
-    const { data: userData } = await sb.auth.getUser();
-    const user = userData?.user;
-    if (!user?.id) return;
+  let profileCache = null; // cache do profile
+  let lockedType = null;   // "PJ" quando role=company; null caso contrário
 
-    const { data: profile } = await sb
-      .from("profiles")
-      .select("*")
-      .eq("id", user.id)
-      .single();
+  async function openOrgModal() {
+    const modal = $("orgModal");
+    if (!modal) return;
 
-    fields.innerHTML = "";
-    const role = profile.role;
-
-    if (role === "company") {
-      fields.innerHTML = `
-        <label>Razão Social</label>
-        <input id="company_name" value="${profile.company_name ?? ""}" placeholder="Ex: Acme Ltda" />
-        <label>CNPJ</label>
-        <input id="company_cnpj" value="${profile.company_cnpj ?? ""}" placeholder="00.000.000/0001-00" />
-      `;
-    } else if (role === "vendor") {
-      fields.innerHTML = `
-        <label>Nome Público</label>
-        <input id="vendor_display_name" value="${profile.vendor_display_name ?? ""}" placeholder="Ex: João Silva" />
-        <label>CPF</label>
-        <input id="vendor_cpf" value="${profile.vendor_cpf ?? ""}" placeholder="000.000.000-00" />
-        <label>LinkedIn (opcional)</label>
-        <input id="vendor_linkedin_url" value="${profile.vendor_linkedin_url ?? ""}" placeholder="https://linkedin.com/in/..." />
-      `;
-    } else {
-      fields.innerHTML = `<p style="color:#ccc">Tipo de conta não definido.</p>`;
+    // Carrega profile para decidir lock/preenche
+    try {
+      const { data: s } = await sb.auth.getSession();
+      const uid = s?.session?.user?.id;
+      if (!uid) throw new Error("Sessão inválida.");
+      const { data, error } = await sb
+        .from("profiles")
+        .select("role, company_name, display_name, document, linkedin_url")
+        .eq("id", uid)
+        .maybeSingle();
+      if (error) throw error;
+      profileCache = data || {};
+    } catch (e) {
+      console.warn("[org] carregar profile:", e);
+      profileCache = {};
     }
 
-    modal.classList.remove("hidden");
-    $("btnCancelProfile").onclick = () => modal.classList.add("hidden");
+    // Se perfil é Empresa, trave em PJ
+    lockedType = profileCache?.role === "company" ? "PJ" : null;
 
-    $("formProfile").onsubmit = async (e) => {
+    // Aplica travas de UI + marca seleção inicial
+    setupOrgTypeUI();
+
+    // Renderiza os campos conforme seleção / lock
+    renderOrgFields();
+
+    // Abre modal
+    show(modal);
+    document.body.classList.add("modal-open");
+  }
+
+  function closeOrgModal() {
+    const modal = $("orgModal");
+    if (!modal) return;
+    hide(modal);
+    document.body.classList.remove("modal-open");
+  }
+
+  function setupOrgTypeUI() {
+    const pj = document.querySelector('input[name="org_type"][value="PJ"]');
+    const pf = document.querySelector('input[name="org_type"][value="PF"]');
+    const pfLabel = pf?.closest("label");
+
+    // Determinar seleção inicial
+    let initial = "PJ";
+    const docDigits = String(profileCache?.document || "").replace(/\D+/g, "");
+    if (!lockedType) {
+      if (docDigits.length === 11) initial = "PF";
+      else if (docDigits.length === 14) initial = "PJ";
+      else initial = profileCache?.role === "vendor" ? "PF" : "PJ";
+    } else {
+      initial = "PJ"; // lock
+    }
+
+    if (pj) pj.checked = initial === "PJ";
+    if (pf) pf.checked = initial === "PF";
+
+    // Se travado: desabilitar PF
+    if (lockedType === "PJ") {
+      if (pf) { pf.disabled = true; pf.setAttribute("aria-disabled", "true"); }
+      pfLabel?.classList.add("is-disabled");
+    } else {
+      if (pf) { pf.disabled = false; pf.removeAttribute("aria-disabled"); }
+      pfLabel?.classList.remove("is-disabled");
+    }
+  }
+
+  let orgFormWired = false;
+  function wireOrgForm() {
+    if (orgFormWired) return;
+    orgFormWired = true;
+
+    const form   = $("orgForm");
+    const cancel = $("btnOrgCancel");
+    const xClose = $("orgClose");
+
+    form?.addEventListener("change", (e) => {
+      const t = e.target;
+      if (t && t.name === "org_type") {
+        if (lockedType === "PJ") { setupOrgTypeUI(); return; } // impede trocar quando lock
+        renderOrgFields();
+      }
+    });
+
+    cancel?.addEventListener("click", (e) => { e.preventDefault(); closeOrgModal(); });
+    xClose?.addEventListener("click", (e) => { e.preventDefault(); closeOrgModal(); });
+
+    form?.addEventListener("submit", async (e) => {
       e.preventDefault();
+      await submitOrgData();
+    });
+  }
 
-      let updates = {};
-      if (role === "company") {
-        const name = $("company_name").value.trim();
-        const cnpj = $("company_cnpj").value.trim();
-        if (!name || !cnpj) return alert("Preencha todos os campos obrigatórios.");
-        updates = { company_name: name, company_cnpj: cnpj };
+  function currentOrgType() {
+    const sel = document.querySelector('input[name="org_type"]:checked');
+    return sel?.value === "PF" ? "PF" : "PJ";
+  }
+
+  // Evitar autofill “grudando” em labels
+  function noiseName(prefix) {
+    return `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  function renderOrgFields() {
+    const box  = $("orgFields");
+    const hint = $("orgHint");
+    if (!box) return;
+
+    const doc = String(profileCache?.document || "");
+    const docDigits = doc.replace(/\D+/g, "");
+
+    if (currentOrgType() === "PJ") {
+      const company_name = profileCache?.company_name || "";
+      const trade_name   = profileCache?.display_name || "";
+      const cnpj         = docDigits.length === 14 ? doc : "";
+
+      box.innerHTML = `
+        <label>Razão social</label>
+        <input id="org_company_name" autocomplete="off" name="${noiseName("company")}" placeholder="Ex.: Acme Ltda" value="${escapeHtml(company_name)}" />
+        <label>Nome fantasia (opcional)</label>
+        <input id="org_trade_name" autocomplete="off" name="${noiseName("trade")}" placeholder="Ex.: Acme" value="${escapeHtml(trade_name)}" />
+        <label>CNPJ</label>
+        <input id="org_document" autocomplete="off" inputmode="numeric" name="${noiseName("cnpj")}" placeholder="00.000.000/0001-00" value="${escapeHtml(cnpj)}" />
+      `;
+      if (hint) hint.textContent = "Pessoa Jurídica: enviaremos para análise após o envio.";
+    } else {
+      const display_name = profileCache?.display_name || "";
+      const cpf          = docDigits.length === 11 ? doc : "";
+      const linkedin     = profileCache?.linkedin_url || "";
+
+      box.innerHTML = `
+        <label>Nome completo</label>
+        <input id="org_display_name" autocomplete="off" name="${noiseName("name")}" placeholder="Ex.: João da Silva" value="${escapeHtml(display_name)}" />
+        <label>CPF</label>
+        <input id="org_document" autocomplete="off" inputmode="numeric" name="${noiseName("cpf")}" placeholder="000.000.000-00" value="${escapeHtml(cpf)}" />
+        <label>LinkedIn (opcional)</label>
+        <input id="org_linkedin_url" autocomplete="off" name="${noiseName("linkedin")}" placeholder="https://linkedin.com/in/..." value="${escapeHtml(linkedin)}" />
+      `;
+      if (hint) hint.textContent = "Fornecedor PF: aprovação automática nesta etapa.";
+    }
+  }
+
+  function escapeHtml(s) {
+    return String(s || "")
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  }
+
+  async function submitOrgData() {
+    const type = currentOrgType();
+    const btn  = $("btnOrgSubmit");
+    btn?.setAttribute("disabled", "true");
+    btn?.classList.add("is-disabled");
+
+    try {
+      const { data: s } = await sb.auth.getSession();
+      const uid = s?.session?.user?.id;
+      if (!uid) throw new Error("Sessão inválida.");
+
+      let patch = {};
+      if (type === "PJ") {
+        const company_name = $("org_company_name")?.value?.trim();
+        const trade_name   = $("org_trade_name")?.value?.trim();
+        const documentId   = $("org_document")?.value?.trim();
+        if (!company_name || !documentId) throw new Error("Preencha Razão social e CNPJ.");
+        patch = {
+          role: "company",
+          company_name,
+          display_name: trade_name || null,
+          document: documentId,
+          profile_review_status: "pending"
+        };
       } else {
-        const name = $("vendor_display_name").value.trim();
-        const cpf = $("vendor_cpf").value.trim();
-        const linkedin = $("vendor_linkedin_url").value.trim();
-        if (!name || !cpf) return alert("Preencha nome e CPF.");
-        updates = {
-          vendor_display_name: name,
-          vendor_cpf: cpf,
-          vendor_linkedin_url: linkedin,
+        const display_name = $("org_display_name")?.value?.trim();
+        const documentId   = $("org_document")?.value?.trim();
+        const linkedin_url = $("org_linkedin_url")?.value?.trim();
+        if (!display_name || !documentId) throw new Error("Preencha Nome e CPF.");
+        patch = {
+          role: "vendor",
+          display_name,
+          document: documentId,
+          linkedin_url: linkedin_url || null,
+          profile_review_status: "approved"
         };
       }
 
-      updates.checklist_profile_done = true;
+      const upd = await sb.from("profiles").update(patch).eq("id", uid);
+      if (upd.error) throw upd.error;
 
-      const { error } = await sb.from("profiles").update(updates).eq("id", user.id);
-      if (error) return alert("Erro ao salvar: " + error.message);
+      alert("Dados enviados para análise.");
+      closeOrgModal();
 
-      alert("Dados salvos com sucesso!");
-      modal.classList.add("hidden");
-      if (typeof renderChecklist === "function") renderChecklist();
-    };
-  }
+      // Atualiza checklist e topo
+      try { await paintUserRole({ user: { id: uid } }); } catch {}
+      if (typeof refreshActivationStatus === "function") await refreshActivationStatus();
 
-  // 🔸 Atacha o evento do botão “Preencher”
-  function bindProfileButton() {
-    const btn = document.getElementById("btnProfile");
-    if (btn) btn.onclick = openProfileModal;
-    else console.warn("⚠️ botão de perfil não encontrado (id=btnProfile)");
+    } catch (e) {
+      console.error("[org] submit error:", e);
+      alert(e?.message || "Erro ao salvar.");
+    } finally {
+      btn?.removeAttribute("disabled");
+      btn?.classList.remove("is-disabled");
+    }
   }
 })();


### PR DESCRIPTION
Este PR implementa e corrige o fluxo completo de “Dados da Organização” no processo de ativação de conta, com suporte a PJ e PF.

Principais mudanças:
- Novo modal claro para seleção e preenchimento dos dados da organização (empresa ou fornecedor).
- Correção do fluxo de travamento (lock) por role — “empresa” (PJ) ou “fornecedor” (PF).
- Prefill automático dos campos existentes no perfil do usuário.
- Atualização automática do checklist de ativação após envio dos dados.
- Proteção adicional de sessão (safeInitAuth) e logout limpo (hardSignOut).
- Ajustes visuais e de consistência no `app.js`, `activation.js` e `activation.css`.

Testado com sucesso em ambiente local:
- Cadastro inicial → seleção de perfil → envio de dados → atualização de status “Em análise”.
- Revalidação de sessão e reabertura do modal com dados persistidos.

Este merge unifica a versão funcional da branch `feat/dados-organizacao` na branch `staging` para validação completa antes da promoção para `main`.
