### PR TITLE
[WIP] feat(vendor): Termos — folha cheia, aceite com checkbox, salvar PDF, telemetria

### DIFF
--- a/docs/vendor-activation/TERMS-flow.md
+++ b/docs/vendor-activation/TERMS-flow.md
@@ -1,0 +1,15 @@
+# Fluxo de ativação — Fornecedor (slice: Termos)
+Este documento acompanha a implementação do passo "Termos" no fluxo de ativação do Fornecedor.
+
+## Objetivo
+- Reutilizar os termos da plataforma (mesma versão dos demais perfis).
+- Gate de aceite + leitura (scroll-to-end + checkbox).
+- Persistir: `profiles.terms_accepted`, `terms_version`, `terms_accepted_at`.
+- Após aceitar, avançar para "Perfil do fornecedor".
+
+## Telemetria mínima (depois):
+- `terms_viewed`, `terms_accepted` (eventos de UI)
+
+## Notas
+- O HTML dos termos é servido em `/legal/terms/pt-BR/<VERSAO>/terms.html`
+- A versão será mantida em constante única (ex.: `TERMS_VER = 1`)

--- a/docs/vendor-activation/checklist.md
+++ b/docs/vendor-activation/checklist.md
@@ -1,0 +1,13 @@
+# Checklist — Fornecedor (Termos)
+
+- [ ] Exibir folha de Termos em tela cheia
+- [ ] Habilitar "Aceitar" somente após leitura + checkbox
+- [ ] Persistir aceite no `profiles`
+- [ ] Redirecionar para o próximo passo do fluxo do fornecedor
+- [ ] (opcional) botão "Salvar PDF" dos termos
+- [ ] (opcional) métrica de aceite/visualização
+
+## Saídas esperadas no PR
+- Código isolado do slice (sem quebrar fluxo de Empresa)
+- Feature flag ou detecção de `role = 'vendor'`
+- Teste manual básico descrito no PR


### PR DESCRIPTION
## Escopo (WIP)
- [ ] Exibir folha de Termos em tela cheia
- [ ] Habilitar "Aceitar" somente após leitura + checkbox
- [ ] Persistir `terms_accepted`, `terms_version`, `terms_accepted_at` em `profiles`
- [ ] Redirecionar para o passo "Perfil do fornecedor" após aceitar
- [ ] (opcional) botão "Salvar PDF"
- [ ] Telemetria mínima: `terms_viewed`, `terms_accepted`

## Técnicos
- HTML servido em `/legal/terms/pt-BR/<VERSAO>/terms.html`
- Versão única controlada por constante (ex.: `TERMS_VER = 1`)
- Detecção de papel `vendor` sem afetar fluxo da Empresa

## Saídas esperadas neste PR
- Slice isolado (não quebrar o fluxo da Empresa)
- Teste manual básico (checklist abaixo)

## Checklist de validação
- [ ] Abre termos em overlay/tela cheia
- [ ] Checkbox controla o botão "Aceitar"
- [ ] Após aceitar, navega para “Perfil do fornecedor”
- [ ] Métrica `terms_accepted` gerada

> Documentação: `docs/vendor-activation/TERMS-flow.md`, `docs/vendor-activation/checklist.md`
